### PR TITLE
make button toggle not scalable

### DIFF
--- a/libs/storybook/src/design-kit/button-toggle/button-toggle.component.scss
+++ b/libs/storybook/src/design-kit/button-toggle/button-toggle.component.scss
@@ -1,0 +1,8 @@
+mat-button-toggle {
+  padding-inline: 0;
+  transition: padding-inline 150ms 45ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+mat-button-toggle:not(.mat-button-toggle-checked) {
+  padding-inline: 15px;
+}

--- a/libs/storybook/src/stories/main/changelog.mdx
+++ b/libs/storybook/src/stories/main/changelog.mdx
@@ -4,6 +4,12 @@ import { Meta } from '@storybook/blocks';
 
 # Changelog
 
+## 2.5.1 (28 May 2025)
+
+**Fixed bugs:**
+
+- Customized the button toggle to prevent it from scaling when an option is selected.
+
 ## 2.5.0 (16 May 2025)
 
 **Fixed bugs:**


### PR DESCRIPTION
Customized the button toggle to prevent it from scaling when an option is selected.