### PR TITLE
fix(symbols): fix material symbols-font-url path to use an `url()` in…

### DIFF
--- a/libs/design-kit/package.json
+++ b/libs/design-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myhealth-belgium/design-kit",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "The MyHealth belgium.be design kit is used for developing web components to integrate with MyHealth.belgium.be.",
   "author": "My Health",
   "license": "MIT",

--- a/libs/design-kit/src/scss/core/_core.scss
+++ b/libs/design-kit/src/scss/core/_core.scss
@@ -13,10 +13,10 @@
 @mixin core(
   $use-material: true,
   $use-local-fonts: true,
-  $symbols-font-path: '../../../assets/fonts/MatSymbols-Rounded.ttf'
+  $symbols-font-url: url('../../../assets/fonts/MatSymbols-Rounded.ttf')
 ) {
   @include mh-fonts.use-font-open-sans($use-local-fonts);
-  @include mh-fonts.use-font-material-symbols($use-local-fonts, $symbols-font-path);
+  @include mh-fonts.use-font-material-symbols($use-local-fonts, $symbols-font-url);
   @include mh-global.use-globals();
   @include mh-global.use-classes();
   @include mh-components.use-all-components();

--- a/libs/design-kit/src/scss/core/typography/_font-material-symbols.scss
+++ b/libs/design-kit/src/scss/core/typography/_font-material-symbols.scss
@@ -1,10 +1,13 @@
-@mixin use-font-material-symbols($use-local-fonts: true, $symbols-font-path: '') {
+@mixin use-font-material-symbols(
+  $use-local-fonts: true,
+  $symbols-font-url: url('../../../assets/fonts/MatSymbols-Rounded.ttf')
+) {
   @if ($use-local-fonts) {
     @font-face {
       font-family: 'Material Symbols Rounded';
       font-style: normal;
       font-weight: 100 700;
-      src: url($symbols-font-path) format('truetype');
+      src: $symbols-font-url format('truetype');
     }
   } @else {
     @font-face {

--- a/libs/storybook/src/stories/foundations/mixins.mdx
+++ b/libs/storybook/src/stories/foundations/mixins.mdx
@@ -15,7 +15,7 @@ This mixin allows the following variables to be passed: `$use-material: boolean`
 
 - `$use-material` is a boolean that dictates if `core()` **includes Angular Material** theme in the design kit or not.
 - `$use-local-fonts` is a boolean that dictates if `core()` includes the **local fonts or** gets them from the **Google Fonts CDN**.
-- `$symbols-font-path` is a string that specifies the path to the Material Symbols font file. This is only used if `$use-local-fonts` is set to `true`.
+- `$symbols-font-url` is an `url()` that specifies the path to the Material Symbols font file. This is only used if `$use-local-fonts` is set to `true`.
 
 This mixin in turn calls following mixins:
 
@@ -44,7 +44,7 @@ The `use-font-material-symbols($use-material, $use-local-fonts)` includes the Op
 This mixin allows the following variables to be passed: `$use-local-fonts: boolean`.
 
 - `$use-local-fonts` is a boolean that dictates if `use-font-open-sans()` includes the **local fonts or** gets them from the **Google Fonts CDN**.
-- `$symbols-font-path` is a string that specifies the path to the Material Symbols font file. This is only used if `$use-local-fonts` is set to `true`.
+- `$symbols-font-url` is an `url()` that specifies the path to the Material Symbols font file. This is only used if `$use-local-fonts` is set to `true`.
 
 #### Optimization
 

--- a/libs/storybook/src/stories/foundations/symbols.mdx
+++ b/libs/storybook/src/stories/foundations/symbols.mdx
@@ -18,19 +18,19 @@ Because you will need more icons than just the ones in Storybook, we will guide 
 2. Download the TTF file and include it in your application.
 3. Include the downloaded file in your SCSS by passing it to the `mh.core()` mixin :
 
-   ```css
-   @use '@myhealth-belgium/design-kit' as mh;
+```css
+@use '@myhealth-belgium/design-kit' as mh;
 
-   @include mh.core($use-material: true, $use-local-fonts: true, $symbols-font-path: 'assets/symbols.ttf');
-   ```
+@include mh.core($use-material: true, $use-local-fonts: true, $symbols-font-url: url('assets/symbols.ttf'));
+```
 
-   Make sure `$use-local-fonts` is set to `true` and `$symbols-font-path` points to the location of the TTF file in your application.
+Make sure `$use-local-fonts` is set to `true` and `$symbols-font-url` points to the location of the TTF file in your application.
 
-   Alternatively, you can also pass it directly to the symbols mixin if you're not using the `mh.core()` mixin:
+Alternatively, you can also pass it directly to the symbols mixin if you're not using the `mh.core()` mixin:
 
-   ```css
-   @include mh-fonts.use-font-material-symbols($use-local-fonts: true, $symbols-font-path: 'assets/symbols.ttf');
-   ```
+```css
+@include mh-fonts.use-font-material-symbols($use-local-fonts: true, $symbols-font-url: url('assets/symbols.ttf'));
+```
 
 ### Symbols download script
 

--- a/libs/storybook/src/stories/main/changelog.mdx
+++ b/libs/storybook/src/stories/main/changelog.mdx
@@ -4,20 +4,21 @@ import { Meta } from '@storybook/blocks';
 
 # Changelog
 
-## 3.0.3 (12 June 2025)
+## 3.0.2 (12 June 2025)
+
+**Fixed bugs:**
+
+- Fixed issue with the `mh.core()` mixin not applying the Material Symbols font correctly when using the `$symbols-font-url` parameter.
+- Renamed `$symbols-font-path` to `$symbols-font-url` to indicate it's an `url()` parameter instead of a `string` path.
+- Updated [Material Symbols](/docs/foundations-symbols--docs) documentation to reflect this change.
 
 **Documentation updated:**
 
+- Table
 - Slide toggle
 - Alert
 - Menu
 - Selectors
-
-## 3.0.2 (12 June 2025)
-
-**Chore:**
-
-- Update table docs
 
 ## 3.0.1 (10 June 2025)
 


### PR DESCRIPTION
…stead of `string` for better build process