### PR TITLE
feat(button-toggle): add error state to button-toggle

### DIFF
--- a/libs/design-kit/package.json
+++ b/libs/design-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myhealth-belgium/design-kit",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "description": "The MyHealth belgium.be design kit is used for developing web components to integrate with MyHealth.belgium.be.",
   "author": "My Health",
   "license": "MIT",

--- a/libs/design-kit/src/scss/material/components/_button-toggle.scss
+++ b/libs/design-kit/src/scss/material/components/_button-toggle.scss
@@ -35,6 +35,59 @@
         }
       }
     }
+
+    &.invalid {
+      border-color: mh.$border-semantic-error-medium;
+      mat-button-toggle.mat-button-toggle {
+        color: mh.$typography-semantic-error-medium;
+        &:hover:not(.mat-button-toggle-checked) {
+          color: mh.$typography-semantic-error-medium;
+          background-color: mh.$surface-semantic-error-lighter;
+        }
+
+        & + mat-button-toggle.mat-button-toggle {
+          border-color: mh.$border-semantic-error-medium;
+
+          &:hover {
+            border-color: mh.$border-semantic-error-dark;
+          }
+          &:focus {
+            border-color: mh.$border-semantic-error-darker;
+          }
+          &.mat-button-toggle-disabled {
+            border-color: mh.$border-brand-neutral-medium;
+          }
+        }
+      }
+    }
+  }
+
+  .mh-button-toggle-subscript-wrapper {
+    display: block;
+    width: fit-content;
+    font: var(--mat-sys-body-small);
+    -webkit-font-smoothing: antialiased;
+    margin-top: 2px;
+    &::before {
+      content: '';
+      display: inline-block;
+      height: mh.$spacing-m;
+    }
+    .mh-button-toggle-error-wrapper {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      background-color: mh.$error-95;
+      color: mh.$error-25;
+      padding: 2px 8px;
+      border-radius: 2px;
+
+      .mat-icon {
+        font-size: var(--mat-sys-body-small-size);
+        height: 1em;
+        width: 1em;
+      }
+    }
   }
 
   @include mat.button-toggle-overrides(

--- a/libs/design-kit/src/scss/material/components/_form-field.scss
+++ b/libs/design-kit/src/scss/material/components/_form-field.scss
@@ -15,6 +15,10 @@
         color: mh.$typography-semantic-error-medium;
       }
 
+      &:has(+ div .mat-button-toggle-group.disabled) {
+        color: mh.$typography-brand-neutral-medium;
+      }
+
       &:has(+ .mat-mdc-form-field.mat-form-field-disabled) {
         color: mh.$typography-brand-neutral-medium;
       }

--- a/libs/storybook/src/design-kit/button-toggle/button-toggle.component.html
+++ b/libs/storybook/src/design-kit/button-toggle/button-toggle.component.html
@@ -1,5 +1,33 @@
+@switch (view()) { @case ('default') {
 <mat-button-toggle-group name="numbers" [disabled]="disabled()">
   <mat-button-toggle value="one">Bold</mat-button-toggle>
   <mat-button-toggle value="two">Italic</mat-button-toggle>
   <mat-button-toggle value="three">Underline</mat-button-toggle>
 </mat-button-toggle-group>
+} @case ('error') {
+<div class="mh-form-field">
+  <label for="field1" class="mh-button-toggle-label"
+    >Label <span aria-hidden="true" class="mh-label-required">*</span></label
+  >
+  <div>
+    <mat-button-toggle-group
+      id="field1"
+      [formControl]="fontStyleControl"
+      [class.invalid]="fontStyleControl.invalid"
+      [class.disabled]="fontStyleControl.disabled"
+    >
+      <mat-button-toggle value="one">Bold</mat-button-toggle>
+      <mat-button-toggle value="two">Italic</mat-button-toggle>
+      <mat-button-toggle value="three">Underline</mat-button-toggle>
+    </mat-button-toggle-group>
+  </div>
+  <div class="mh-button-toggle-subscript-wrapper">
+    @if (fontStyleControl.invalid && fontStyleControl.touched) {
+    <div class="mh-button-toggle-error-wrapper">
+      <mat-icon class="mh-suffix-error" matSuffix>error</mat-icon>
+      <mat-error class="mh-button-toggle-error">This field is required</mat-error>
+    </div>
+    }
+  </div>
+</div>
+} }

--- a/libs/storybook/src/design-kit/button-toggle/button-toggle.component.ts
+++ b/libs/storybook/src/design-kit/button-toggle/button-toggle.component.ts
@@ -1,12 +1,42 @@
-import { Component, input, InputSignal } from '@angular/core';
+import { Component, effect, input, InputSignal } from '@angular/core';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
+import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatError, MatFormField, MatLabel, MatSuffix } from '@angular/material/input';
+import { MatIcon } from '@angular/material/icon';
+import { MatButton } from '@angular/material/button';
 
 @Component({
   selector: 'mh-button-toggle',
-  imports: [MatButtonToggleModule],
+  imports: [
+    MatButtonToggleModule,
+    ReactiveFormsModule,
+    MatError,
+    MatIcon,
+    MatSuffix,
+    MatFormField,
+    MatLabel,
+    MatButton,
+  ],
   templateUrl: './button-toggle.component.html',
   styleUrl: './button-toggle.component.scss',
 })
 export class ButtonToggleComponent {
+  readonly view = input<'default' | 'error'>('default');
   readonly disabled: InputSignal<boolean> = input.required();
+  readonly fontStyleControl = new FormControl(
+    { value: undefined, disabled: false },
+    { validators: [Validators.required] }
+  );
+
+  constructor() {
+    this.fontStyleControl.markAsTouched();
+
+    effect(() => {
+      if (this.disabled()) {
+        this.fontStyleControl.disable();
+      } else {
+        this.fontStyleControl.enable();
+      }
+    });
+  }
 }

--- a/libs/storybook/src/design-kit/button-toggle/button-toggle.stories.ts
+++ b/libs/storybook/src/design-kit/button-toggle/button-toggle.stories.ts
@@ -19,3 +19,10 @@ export const Default: Story = {
     disabled: false,
   },
 };
+
+export const Error: Story = {
+  args: {
+    disabled: false,
+    view: 'error',
+  },
+};

--- a/libs/storybook/src/stories/components/button-toggle.mdx
+++ b/libs/storybook/src/stories/components/button-toggle.mdx
@@ -43,6 +43,43 @@ Depending on the type of selection, there are 2 categories segmented buttons:
 - **Multi-select buttons** are an alternative to checkboxes, allowing users to select multiple options simultaneously.
   - Always **communicate clearly** that multiple selections are allowed (e.g., “Select one or more options”).
 
+### Class for form-field use
+
+The MyHealth Design System requires labels to be placed outside of the segmented button. To achieve this, wrap the entire field in a div with the mh-form-field class.
+Make sure the label is linked to the segmented button by setting the `for` attribute on the label and a matching `id` on the `mat-button-toggle-group`.
+
+When the field is `required`, add a span with the `mh-label-required` class inside the label to render the required indicator. Set `aria-hidden="true"` on it so screen readers rely on the control's own required state instead.
+
+Apply `[class.invalid]` and `[class.disabled]` bindings on the toggle group to reflect the form control's state for styling purposes.
+The error message is rendered below the toggle group inside a mh-button-toggle-subscript-wrapper. It is only shown when the control is both invalid and touched.
+
+```html
+<div class="mh-form-field">
+  <label for="field1">Label <span aria-hidden="true" class="mh-label-required">*</span></label>
+  <div>
+    <mat-button-toggle-group
+      id="field1"
+      [formControl]="fontStyleControl"
+      [class.invalid]="fontStyleControl.invalid"
+      [class.disabled]="fontStyleControl.disabled"
+    >
+      <mat-button-toggle value="one">Bold</mat-button-toggle>
+      <mat-button-toggle value="two">Italic</mat-button-toggle>
+      <mat-button-toggle value="three">Underline</mat-button-toggle>
+    </mat-button-toggle-group>
+  </div>
+
+  <div class="mh-button-toggle-subscript-wrapper">
+    @if (fontStyleControl.invalid && fontStyleControl.touched) {
+    <div class="mh-button-toggle-error-wrapper">
+      <mat-icon class="mh-suffix-error" matSuffix>error</mat-icon>
+      <mat-error class="mh-button-toggle-error">This field is required</mat-error>
+    </div>
+    }
+  </div>
+</div>
+```
+
 ### When to use it
 
 - Use a segmented button when there are **two to five available options**.

--- a/libs/storybook/src/stories/main/changelog-design-kit.mdx
+++ b/libs/storybook/src/stories/main/changelog-design-kit.mdx
@@ -4,6 +4,12 @@ import { Meta } from '@storybook/blocks';
 
 # Changelog Design Kit
 
+## 4.1.5 (31 March 2026)
+
+**New features:**
+
+- Added an `error` state for the [Segmented button component](/docs/angular-components-buttons-cta-toggle--error).
+
 ## 4.1.4 (26 March 2026)
 
 **Bug fixes:**


### PR DESCRIPTION
Add error state for button toggle when used in a form.
I added the error below, however the Figma shows it above.
But since all other errors are below I kept it like this. If it changes in the future we need to move this one ass well.